### PR TITLE
Feature/duel channel alt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,25 @@ dependencies = [
 name = "components_macros"
 version = "0.1.0"
 dependencies = [
+ "itertools",
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
 ]
 
 [[package]]

--- a/components/src/channels.rs
+++ b/components/src/channels.rs
@@ -1,6 +1,17 @@
-pub trait Channel<T>: std::marker::Copy {
-    fn set(&self, value: T) -> Self;
+use std::marker::Copy;
+
+pub trait Channel<T>: Copy {
     fn get(&self) -> T;
+    fn set(&self, value: T) -> Self;
+}
+
+pub trait DuelChannel<A, B>: Copy + Channel<A> + Channel<B> {
+    fn duel_get(&self) -> A {
+        self.get()
+    }
+    fn duel_set(&self, value: B) -> Self {
+        self.set(value)
+    }
 }
 
 #[cfg(test)]

--- a/components/src/channels.rs
+++ b/components/src/channels.rs
@@ -33,6 +33,21 @@ mod tests {
         assert_eq!(channel.event, new_event);
     }
 
+    #[test]
+    fn test_duel_get() {
+        let channel = get_test_channel();
+        let event: Event = channel.duel_get();
+        assert_eq!(event, channel.event);
+    }
+
+    #[test]
+    fn test_duel_set() {
+        let channel = get_test_channel();
+        let new_event = Event::Exit;
+        let channel = channel.duel_set(new_event);
+        assert_eq!(channel.event, new_event);
+    }
+
     fn get_test_channel() -> EventChannel {
         EventChannel {
             event: Event::Keyboard,
@@ -54,6 +69,8 @@ mod tests {
             self.event
         }
     }
+
+    impl DuelChannel<Event, Event> for EventChannel {}
 
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     enum Event {

--- a/components/src/lib.rs
+++ b/components/src/lib.rs
@@ -4,6 +4,7 @@ pub mod channels;
 #[doc(hidden)]
 pub mod __private {
     pub use crate::channels::Channel;
+    pub use crate::channels::DuelChannel;
 }
 
 #[cfg(feature = "macros")]

--- a/components/tests/macros.rs
+++ b/components/tests/macros.rs
@@ -1,4 +1,5 @@
 use components::channels::Channel;
+use components::channels::DuelChannel;
 use components::Channels;
 
 #[test]
@@ -13,6 +14,21 @@ fn test_derive_channels_set() {
     let channel = get_test_channel();
     let new_position = (-5, 20);
     let channel = channel.set(new_position);
+    assert_eq!(channel.position, new_position);
+}
+
+#[test]
+fn test_derive_duel_channels_get() {
+    let channel = get_test_channel();
+    let color: Rgb = channel.duel_get();
+    assert_eq!(color, channel.color);
+}
+
+#[test]
+fn test_derive_duel_channels_set() {
+    let channel = get_test_channel();
+    let new_position = (-5, 20);
+    let channel = channel.duel_set(new_position);
     assert_eq!(channel.position, new_position);
 }
 

--- a/components_macros/Cargo.toml
+++ b/components_macros/Cargo.toml
@@ -8,6 +8,7 @@ proc-macro = true
 name = "components_macros"
 
 [dependencies]
+itertools = "0.14.0"
 proc-macro2 = "1.0.101"
 quote = "1.0.40"
-syn = "2.0.106"
+syn = { version = "2.0.106", features = ["extra-traits"] }

--- a/components_macros/src/lib.rs
+++ b/components_macros/src/lib.rs
@@ -3,6 +3,7 @@ extern crate proc_macro;
 use proc_macro2::{TokenStream, Span};
 use quote::quote;
 use syn::{Data, DeriveInput};
+use itertools::Itertools;
 
 #[proc_macro_derive(Channels)]
 pub fn channels(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
@@ -22,22 +23,32 @@ fn channels_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
         _ => return Err(non_struct_error()),
     };
 
-    let generated_code = fields.iter().map(|f| (f.clone().ident.expect("struct fields have names"), f.ty.clone())).map(|(field, ty)| {
+    let fields = fields.iter().map(|f| (f.clone().ident.expect("struct fields have names"), f.ty.clone()));
+    let channel_impls = fields.clone().map(|(field, ty)| {
         quote! {
             impl #impl_generics ::components::__private::Channel<#ty> for #name #ty_generics #where_clause {
+                fn get(&self) -> #ty {
+                    self.#field
+                }
                 fn set(&self, value: #ty) -> Self {
                     let mut clone = *self;
                     clone.#field = value;
                     clone
                 }
-                fn get(&self) -> #ty {
-                    self.#field
-                }
             }
         }
     });
+    let duel_channel_impls = fields.clone().cartesian_product(fields)
+        .map(|(a, b)| (a.1, b.1))
+        .filter(|(a, b)| a != b)
+        .map(|(ty_a, ty_b)| {
+            quote! {
+                impl #impl_generics ::components::__private::DuelChannel<#ty_a, #ty_b> for #name #ty_generics #where_clause {}
+            }
+        });
     Ok(quote! {
-        #(#generated_code)*
+        #(#channel_impls)*
+        #(#duel_channel_impls)*
     })
 }
 


### PR DESCRIPTION
Add a trait that describes two channels at the same time, one for reading and one for writing.
Mainly now for boxing because `Box<dyn Channel<A> + Channel<B>>` is not allowed in rust, so this feature allows `Box<dyn DuelChannel<A, B>>` 
This only works for the special case that you only need reading for one channel (`Channel<A>`) and writing for another  (`Channel<B>`)