### PR TITLE
Make fns const where ever possible

### DIFF
--- a/components/src/channels.rs
+++ b/components/src/channels.rs
@@ -48,7 +48,7 @@ mod tests {
         assert_eq!(channel.event, new_event);
     }
 
-    fn get_test_channel() -> EventChannel {
+    const fn get_test_channel() -> EventChannel {
         EventChannel {
             event: Event::Keyboard,
         }

--- a/components/src/processes.rs
+++ b/components/src/processes.rs
@@ -11,7 +11,7 @@ pub struct Assign<T> {
 }
 
 impl<T> Assign<T> {
-    pub fn new(value: T) -> Self {
+    pub const fn new(value: T) -> Self {
         Self { value }
     }
 }
@@ -39,7 +39,7 @@ impl<A, B, F> Map<A, B, F>
 where
     F: Fn(A) -> B,
 {
-    pub fn new(map: F) -> Self {
+    pub const fn new(map: F) -> Self {
         Self { map, phantom_a: PhantomData, phantom_b: PhantomData }
     }
 }
@@ -63,7 +63,7 @@ pub struct Chain<C> {
 }
 
 impl<C> Chain<C> {
-    pub fn new(processes: Vec<Box<dyn Process<C>>>) -> Self {
+    pub const fn new(processes: Vec<Box<dyn Process<C>>>) -> Self {
         Self { processes }
     }
 }
@@ -120,7 +120,7 @@ mod tests {
         assert_eq!(new_channel.position, new_position);
     }
 
-    fn get_test_channel() -> GraphicsChannel {
+    const fn get_test_channel() -> GraphicsChannel {
         GraphicsChannel {
             position: (50, 50),
             color: Rgb { red: 255, green: 0, blue: 0 },

--- a/components/tests/macros.rs
+++ b/components/tests/macros.rs
@@ -32,7 +32,7 @@ fn test_derive_duel_channels_set() {
     assert_eq!(channel.position, new_position);
 }
 
-fn get_test_channel() -> GraphicsChannel {
+const fn get_test_channel() -> GraphicsChannel {
     let color = Rgb {
         red: 255,
         green: 0,


### PR DESCRIPTION
Fix by warnings emitted from `cargo clippy -- -W clippy::nursery`